### PR TITLE
Alignment fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lua_bind_hash"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["jam1garner <jam1.mcleod@hotmail.com>", "jugeeya <jugeeya@live.com>"]
 edition = "2018"
 

--- a/lua_bind_hash.rs
+++ b/lua_bind_hash.rs
@@ -1,14 +1,16 @@
-use std::{mem, slice};
+#![allow(clippy::precedence)]
+
+use std::mem::transmute_copy;
 
 #[allow(non_snake_case)]
 pub fn lua_bind_hash(data_bytes: &[u8]) -> u64 {
     let mut len = data_bytes.len() as u64;
-    
+
     let mut hash_vals: [u64; 4] = [
-       0x60ea27eeadc0b5d5,
-       0xc2b2ae3d27d4eb4e,
-       0xffffffffffffffff,
-       0x61c8864e7a143578,
+        0x60ea27eeadc0b5d5,
+        0xc2b2ae3d27d4eb4e,
+        0xffffffffffffffff,
+        0x61c8864e7a143578,
     ];
 
     let mut hash_vals_mid = [0u64; 4];
@@ -17,15 +19,10 @@ pub fn lua_bind_hash(data_bytes: &[u8]) -> u64 {
         0x3c6ef3630bd7950e,
         0x1bbcd8c2f5e54380,
         0x779b185ebca87000,
-        0xe6c617af2a1c0000
+        0xe6c617af2a1c0000,
     ];
 
-    let hash_vals_end_shift: [u64; 4] = [
-        0x3f,
-        0x39,
-        0x34,
-        0x2e
-    ];
+    let hash_vals_end_shift: [u64; 4] = [0x3f, 0x39, 0x34, 0x2e];
 
     const MULT1: u64 = 0x87bcb65480000000;
     const MULT2: u64 = 0xdef35b010f796ca9;
@@ -35,25 +32,16 @@ pub fn lua_bind_hash(data_bytes: &[u8]) -> u64 {
     const MULT6: u64 = 0x27d4eb2f165667c5;
     const ADD1: u64 = 0x85ebca77c2b2ae63;
     const ADD2: u64 = 0x165667b19e3779f9;
-    
+
     let mut lVar5 = 0x27d4eb2f165667c4;
-    let chunks_32 = data_bytes.chunks_exact(32);
-    let chunks_8 = chunks_32.remainder().chunks_exact(8);
-    let chunks_4 = chunks_8.remainder().chunks_exact(4);
-    let data_1 = chunks_4.remainder().iter();
-    let data_32 = chunks_32.map(|chunk| unsafe {
-                    slice::from_raw_parts(
-                        chunk.as_ptr() as *const u64,
-                        32usize / mem::size_of::<u64>()
-                    )
-                  });
-    let data_8 = chunks_8.map(|chunk| unsafe { *(chunk.as_ptr() as *const u64) });
-    let mut data_4 = chunks_4.map(|chunk| unsafe { *(chunk.as_ptr() as *const u32) });
-    
+    let (_, chunks_32, rest) = unsafe { data_bytes.align_to::<[[u8; 8]; 4]>() };
+    let (_, chunks_8, rest) = unsafe { rest.align_to::<[u8; 8]>() };
+    let (_, chunks_4, data_1) = unsafe { rest.align_to::<[u8; 4]>() };
+
     if len >= 0x20 {
-        for chunk in data_32 {
-            for i in 0..4 {
-                hash_vals[i] += chunk[i] * MULT4;
+        for chunk in chunks_32 {
+            for (i, block) in chunk.iter().enumerate() {
+                hash_vals[i] += unsafe { transmute_copy::<[u8; 8], u64>(block) } * MULT4;
                 hash_vals_mid[i] = hash_vals[i] >> 0x21 | hash_vals[i] * 0x80000000;
                 hash_vals[i] = hash_vals_mid[i] * MULT3;
             }
@@ -66,7 +54,9 @@ pub fn lua_bind_hash(data_bytes: &[u8]) -> u64 {
 
         val = (val ^ (hash_vals_mid[0] * MULT1 | hash_vals_mid[0] * MULT2 >> 0x21) * MULT3) * MULT3;
         for i in 1..4 {
-            val = (val + ADD1 ^ (hash_vals_mid[i] * MULT1 | hash_vals_mid[i] * MULT2 >> 0x21) * MULT3) * MULT3;
+            val = (val + ADD1
+                ^ (hash_vals_mid[i] * MULT1 | hash_vals_mid[i] * MULT2 >> 0x21) * MULT3)
+                * MULT3;
         }
         val += ADD1;
 
@@ -74,20 +64,21 @@ pub fn lua_bind_hash(data_bytes: &[u8]) -> u64 {
     }
 
     len += lVar5;
-    
-    for n in data_8 {
-        len = (n * MULT5 | (n * MULT4) >> 0x21) *
-            MULT3 ^ len;
+
+    for block in chunks_8 {
+        let n = unsafe { transmute_copy::<[u8; 8], u64>(block) };
+        len ^= (n * MULT5 | (n * MULT4) >> 0x21) * MULT3;
         len = (len >> 0x25 | len << 0x1b) * MULT3 + ADD1;
     }
 
-    if let Some(n) = data_4.nth(0) {
-        len = n as u64 * MULT3 ^ len;
+    if let Some(block) = chunks_4.first() {
+        let n = unsafe { transmute_copy::<[u8; 4], u32>(block) };
+        len ^= n as u64 * MULT3;
         len = (len >> 0x29 | len << 0x17) * MULT4 + ADD2;
     }
 
     for n in data_1 {
-        len = *n as u64 * MULT6 ^ len;
+        len ^= *n as u64 * MULT6;
         len = (len >> 0x35 | len << 0xb) * MULT3;
     }
 
@@ -98,12 +89,12 @@ pub fn lua_bind_hash(data_bytes: &[u8]) -> u64 {
 }
 
 pub fn lua_bind_hash_str<S: AsRef<str>>(string: S) -> u64 {
-    lua_bind_hash(string.as_ref().as_bytes())   
+    lua_bind_hash(string.as_ref().as_bytes())
 }
 
 fn main() {
     let tests = vec![
-        "password", 
+        "password",
         "password1234",
         "FIGHTER_STATUS_DAMAGE_WORK_FLOAT_VECOR_CORRECT_STICK_X",
     ];
@@ -119,12 +110,27 @@ mod tests {
     #[test]
     fn test_all_test_strings() {
         let tests = vec![
-            ("password", 0xe58325ff3537c13a), 
+            ("password", 0xe58325ff3537c13a),
             ("password1234", 0xa26a67b576fe1e83),
             ("FIGHTER_STATUS_DAMAGE_WORK_FLOAT_VECOR_CORRECT_STICK_X", 0xa4d50a730e36970e),
         ];
         for test in tests {
             assert_eq!(lua_bind_hash_str(test.0), test.1);
         }
+    }
+
+    #[repr(C, align(8))]
+    struct AlignBytes<const N: usize>([u8; N]);
+
+    static _ALIGNED: AlignBytes<55> =
+        AlignBytes(*b"_FIGHTER_STATUS_DAMAGE_WORK_FLOAT_VECOR_CORRECT_STICK_X");
+    static ALIGNED: &str = unsafe { std::str::from_utf8_unchecked(_ALIGNED.0.as_slice()) };
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_misaligned_str() {
+        let MISALIGNED = &ALIGNED[1..];
+        assert_eq!(MISALIGNED.as_ptr() as usize % 4, 1);
+        assert_eq!(lua_bind_hash_str(MISALIGNED), 0xa4d50a730e36970e);
     }
 }


### PR DESCRIPTION
The code as it exists today contains undefined behavior: pointers to bytes are cast to pointers to types with higher alignment requirements and this alignment is not checked. This PR fixes that b[y `transmute_copy`](https://doc.rust-lang.org/std/mem/fn.transmute_copy.html)ing the values, which does respect alignment requirements.